### PR TITLE
OpenACC shared memory in axhelm

### DIFF
--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -560,6 +560,7 @@ c
 
       real s_dxm1(lx1+1,ly1)
       real s_u_ur(lx1+1,ly1)
+      real s_us(lx1+1,ly1)
 
       integer e
       real tmpu1,tmpu2,tmpu3
@@ -591,9 +592,9 @@ c
          call exitt()
       else
 !$acc parallel num_gangs(lelt)
-!$acc loop gang private(s_dxm1,s_u_ur)
+!$acc loop gang private(s_dxm1,s_u_ur,s_us)
          do e=1,lelt
-!$acc cache(s_dxm1,s_u_ur)
+!$acc cache(s_dxm1,s_u_ur,s_us)
 !$acc loop vector tile(lx1,ly1)
             do j=1,ly1
                do i=1,lx1
@@ -624,11 +625,10 @@ c
      $                    + tmpu1*g1m1(i,j,k,e)
      $                    + tmpu2*g4m1(i,j,k,e)
      $                    + tmpu3*g5m1(i,j,k,e))
-                     tmp2(i,j,k,e) = helm1(i,j,k,e)*(
+                     s_us(i,j) = helm1(i,j,k,e)*(
      $                    + tmpu2*g2m1(i,j,k,e)
      $                    + tmpu1*g4m1(i,j,k,e)
      $                    + tmpu3*g6m1(i,j,k,e))
-
 
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu3*g3m1(i,j,k,e)
@@ -645,7 +645,7 @@ c
 !$acc loop seq
                      do l=1,lx1
                         tmpu1 = tmpu1 + s_dxm1(l,i)*s_u_ur(l,j)
-                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*s_us(i,l)
                      enddo
                      au(i,j,k,e) = tmpu1 + tmpu2
                   enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -555,12 +555,8 @@ c
      $ ,             tmp2  (lx1*ly1*lz1*lelt)
      $ ,             tmp3  (lx1*ly1*lz1*lelt)
 
-      real           tm1   (lx1*ly1*lz1)
-      real           tm2   (lx1*ly1*lz1)
-      real           tm3   (lx1*ly1*lz1)
       real           duax  (lx1)
       real           ysm1  (lx1)
-      equivalence    (dudr,tm1),(duds,tm2),(dudt,tm3)
 
       integer e
       real tmpu1,tmpu2,tmpu3
@@ -645,11 +641,11 @@ c
 !$ACC END PARALLEL
 
 !FIXME: Div should also include summation
-         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,tm1,tm2,tm3)
+         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
 
 !$ACC PARALLEL LOOP GANG VECTOR
          do i=1,ntot
-            au(i) = tm1(i)+tm2(i)+tm3(i)
+            au(i) = dudr(i)+duds(i)+dudt(i)
          enddo
 !$ACC END PARALLEL
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -653,40 +653,48 @@ c
 !$acc parallel loop collapse(4) gang worker vector
 !$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
       do e=1,nelv
-      do k=1,nz1
-      do j=1,ny1
-      do i=1,nx1
-         ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $      (e-1)*nx1*ny1*nz1
-         tmpu1 = 0.0
-         tmpu2 = 0.0
-         tmpu3 = 0.0
+         do k=1,nz1
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  tmpu1 = 0.0
+                  tmpu2 = 0.0
+                  tmpu3 = 0.0
 !$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
-         do l=1,nx1
-            ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
-            tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
-            tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                  do l=1,nx1
+                     ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+                     tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+                     tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                  enddo
+!$acc end loop
+                  dudr(ijke) = tmpu1
+                  duds(ijke) = tmpu2
+                  dudt(ijke) = tmpu3
+               enddo
+            enddo
          enddo
-!$acc    end loop
-         dudr(ijke) = tmpu1
-         duds(ijke) = tmpu2
-         dudt(ijke) = tmpu3
-      enddo
-      enddo
-      enddo
       enddo
 !$acc end parallel loop
 
 !$ACC PARALLEL LOOP GANG VECTOR
-         do i=1,ntot
-            au(i) = dudr(i)+duds(i)+dudt(i)
+      do e=1,nelv
+         do k=1,nz1
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+               enddo
+            enddo
          enddo
+      enddo
 !$ACC END PARALLEL
 
       endif

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -582,13 +582,11 @@ c
 !$ACC DATA CREATE(dudr,duds,dudt,tmp1,tmp2,tmp3)
 !$ACC& PRESENT(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1)
 !$ACC& PRESENT(dxm1,dxtm1,au,u,helm1,helm2)
-
       if (ndim.eq.2) then
          if(nid.eq.0) write(6,*)
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-
 !$acc parallel num_gangs(nelt)
 !$acc loop gang
          do e=1,nelt
@@ -621,82 +619,91 @@ c
                enddo
             enddo
 !$acc loop seq
-         do k=1,nz1
+            do k=1,nz1
 !$acc loop vector tile(nx1,ny1) private(ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  tmp1(ijke) = helm1(ijke)*(
-     $                 + dudr(ijke)*g1m1(i,j,k,e)
-     $                 + duds(ijke)*g4m1(i,j,k,e)
-     $                 + dudt(ijke)*g5m1(i,j,k,e))
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmp1(ijke) = helm1(ijke)*(
+     $                    + dudr(ijke)*g1m1(i,j,k,e)
+     $                    + duds(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g5m1(i,j,k,e))
 
-                  tmp2(ijke) = helm1(ijke)*(
-     $                 + duds(ijke)*g2m1(i,j,k,e)
-     $                 + dudr(ijke)*g4m1(i,j,k,e)
-     $                 + dudt(ijke)*g6m1(i,j,k,e))
+                     tmp2(ijke) = helm1(ijke)*(
+     $                    + duds(ijke)*g2m1(i,j,k,e)
+     $                    + dudr(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g6m1(i,j,k,e))
 
-                  tmp3(ijke) = helm1(ijke)*(
-     $                 + dudt(ijke)*g3m1(i,j,k,e)
-     $                 + dudr(ijke)*g5m1(i,j,k,e)
-     $                 + duds(ijke)*g6m1(i,j,k,e))
-               enddo
-            enddo
-         enddo
-!$acc loop seq
-         do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  tmpu1 = 0.0
-                  tmpu2 = 0.0
-                  tmpu3 = 0.0
-!$acc loop seq private(ljke,ilke,ijle)
-                  do l=1,nx1
-                     ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
-                     tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
-                     tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                     tmp3(ijke) = helm1(ijke)*(
+     $                    + dudt(ijke)*g3m1(i,j,k,e)
+     $                    + dudr(ijke)*g5m1(i,j,k,e)
+     $                    + duds(ijke)*g6m1(i,j,k,e))
                   enddo
-                  dudr(ijke) = tmpu1
-                  duds(ijke) = tmpu2
-                  dudt(ijke) = tmpu3
                enddo
             enddo
-         enddo
 !$acc loop seq
-         do k=1,nz1
+            do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmpu1 = 0.0
+                     tmpu2 = 0.0
+                     tmpu3 = 0.0
+!$acc loop seq private(ljke,ilke,ijle)
+                     do l=1,nx1
+                        ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+                        tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+                        tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                     enddo
+                     dudr(ijke) = tmpu1
+                     duds(ijke) = tmpu2
+                     dudt(ijke) = tmpu3
+                  enddo
+               enddo
+            enddo
+!$acc loop seq
+            do k=1,nz1
 !$acc loop vector tile(nx1,ny1) private(ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+                  enddo
                enddo
             enddo
          enddo
-      enddo
 !$acc end parallel
-
       endif
-
       if (ifh2) then
-!$ACC PARALLEL LOOP GANG VECTOR
-         do i=1,ntot
-            au(i) = au(i) + helm2(i)*bm1(i,1,1,1)*u(i)
+!$acc parallel num_gangs(nelt)
+!$acc loop gang
+         do e=1,nelt
+!$acc loop seq
+            do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     au(ijke) = au(ijke) +
+     $                  helm2(ijke)*bm1(i,j,k,e)*u(ijke)
+                  enddo
+               enddo
+            enddo
          enddo
-!$ACC END PARALLEL
+!$acc end parallel
       endif
-
-!$ACC END DATA
+!$acc end data
  
 c     if axisymmetric, add a diagonal term in the radial direction (isd=2)
  

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -646,18 +646,18 @@ c
 !$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
                do j=1,ly1
                   do i=1,lx1
-                     tmpu1 = 0.0
-                     tmpu2 = 0.0
-                     tmpu3 = 0.0
+                     dudr(i,j,k,e) = 0.0
+                     duds(i,j,k,e) = 0.0
+                     dudt(i,j,k,e) = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + s_dxm1(l,i)*tmp1(l,j,k,e)
-                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
-                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
+                        dudr(i,j,k,e) = dudr(i,j,k,e) 
+     $                     + s_dxm1(l,i)*tmp1(l,j,k,e)
+                        duds(i,j,k,e) = duds(i,j,k,e) 
+     $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        dudt(i,j,k,e) = dudt(i,j,k,e) 
+     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
-                     dudr(i,j,k,e) = tmpu1
-                     duds(i,j,k,e) = tmpu2
-                     dudt(i,j,k,e) = tmpu3
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -617,36 +617,32 @@ c
      $                    + tmpu1*g1m1(i,j,k,e)
      $                    + tmpu2*g4m1(i,j,k,e)
      $                    + tmpu3*g5m1(i,j,k,e))
-
                      tmp2(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu2*g2m1(i,j,k,e)
      $                    + tmpu1*g4m1(i,j,k,e)
      $                    + tmpu3*g6m1(i,j,k,e))
 
+
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu3*g3m1(i,j,k,e)
      $                    + tmpu1*g5m1(i,j,k,e)
      $                    + tmpu2*g6m1(i,j,k,e))
+
                   enddo
                enddo
-            enddo
-!$acc loop seq
-            do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
                      dudr(i,j,k,e) = 0.0
                      duds(i,j,k,e) = 0.0
-                     dudt(i,j,k,e) = 0.0
 !$acc loop seq
                      do l=1,lx1
                         dudr(i,j,k,e) = dudr(i,j,k,e) 
      $                     + s_dxm1(l,i)*tmp1(l,j,k,e)
                         duds(i,j,k,e) = duds(i,j,k,e) 
      $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
-                        dudt(i,j,k,e) = dudt(i,j,k,e) 
-     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
+                     au(i,j,k,e) = dudr(i,j,k,e) + duds(i,j,k,e)
                   enddo
                enddo
             enddo
@@ -655,8 +651,12 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     au(i,j,k,e) =
-     $                    dudr(i,j,k,e)+duds(i,j,k,e)+dudt(i,j,k,e)
+                     dudt(i,j,k,e) = 0.0
+                     do l=1,lx1
+                        dudt(i,j,k,e) = dudt(i,j,k,e) 
+     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
+                     enddo
+                     au(i,j,k,e) = au(i,j,k,e) + dudt(i,j,k,e)
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -640,16 +640,14 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     dudr(i,j,k,e) = 0.0
-                     duds(i,j,k,e) = 0.0
+                     tmpu1 = 0.0
+                     tmpu2 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        dudr(i,j,k,e) = dudr(i,j,k,e) 
-     $                     + s_dxm1(l,i)*s_u_ur(l,j)
-                        duds(i,j,k,e) = duds(i,j,k,e) 
-     $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu1 = tmpu1 + s_dxm1(l,i)*s_u_ur(l,j)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
                      enddo
-                     au(i,j,k,e) = dudr(i,j,k,e) + duds(i,j,k,e)
+                     au(i,j,k,e) = tmpu1 + tmpu2
                   enddo
                enddo
             enddo
@@ -658,12 +656,11 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     dudt(i,j,k,e) = 0.0
+                     tmpu3 = 0.0
                      do l=1,lx1
-                        dudt(i,j,k,e) = dudt(i,j,k,e) 
-     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
+                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
-                     au(i,j,k,e) = au(i,j,k,e) + dudt(i,j,k,e)
+                     au(i,j,k,e) = au(i,j,k,e) + tmpu3
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -641,7 +641,39 @@ c
 !$ACC END PARALLEL
 
 !FIXME: Div should also include summation
-         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
+!        CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
+!$acc parallel loop collapse(4) gang worker vector
+!$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
+      do e=1,nelv
+      do k=1,nz1
+      do j=1,ny1
+      do i=1,nx1
+         ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $      (e-1)*nx1*ny1*nz1
+         tmpu1 = 0.0
+         tmpu2 = 0.0
+         tmpu3 = 0.0
+!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+         do l=1,nx1
+            ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+            tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+            tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+         enddo
+!$acc    end loop
+         dudr(ijke) = tmpu1
+         duds(ijke) = tmpu2
+         dudt(ijke) = tmpu3
+      enddo
+      enddo
+      enddo
+      enddo
+!$acc end parallel loop
 
 !$ACC PARALLEL LOOP GANG VECTOR
          do i=1,ntot

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -583,7 +583,7 @@ c
 
 !$ACC DATA CREATE(dudr,duds,dudt,tmp1,tmp2,tmp3)
 !$ACC& PRESENT(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1)
-!$ACC& PRESENT(dxm1,dxtm1,au,u,helm1,helm2)
+!$ACC& PRESENT(dxm1,au,u,helm1,helm2)
       if (ndim.eq.2) then
          if(nid.eq.0) write(6,*)
      $        '2D Not currently implemented on for OpenACC'
@@ -592,13 +592,13 @@ c
 !$acc parallel num_gangs(lelt)
 !$acc loop gang private(s_dxm1)
          do e=1,lelt
+!$acc cache(s_dxm1)
 !$acc loop vector tile(lx1,ly1)
             do j=1,ly1
                do i=1,lx1
                   s_dxm1(i,j) = dxm1(i,j)
                enddo
             enddo
-!$acc cache(s_dxm1)
 !$acc loop seq
             do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
@@ -632,7 +632,7 @@ c
             enddo
 !$acc loop seq
             do k=1,lz1
-!$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
+!$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
                      dudr(i,j,k,e) = 0.0

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -587,19 +587,19 @@ c
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-!$acc parallel num_gangs(nelt)
+!$acc parallel num_gangs(lelt)
 !$acc loop gang
-         do e=1,nelt
+         do e=1,lelt
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
 !$acc loop seq
-                     do l=1,nx1
+                     do l=1,lx1
                         tmpu1 = tmpu1 + dxm1(i,l)*u(l,j,k,e)
                         tmpu2 = tmpu2 + dxm1(j,l)*u(i,l,k,e)
                         tmpu3 = tmpu3 + dxm1(k,l)*u(i,j,l,e)
@@ -611,10 +611,10 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      tmp1(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + dudr(i,j,k,e)*g1m1(i,j,k,e)
      $                    + duds(i,j,k,e)*g4m1(i,j,k,e)
@@ -633,15 +633,15 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
+               do j=1,ly1
+                  do i=1,lx1
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
 !$acc loop seq
-                     do l=1,nx1
+                     do l=1,lx1
                         tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(l,j,k,e)
                         tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(i,l,k,e)
                         tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(i,j,l,e)
@@ -653,10 +653,10 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(ijke)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      au(i,j,k,e) =
      $                    dudr(i,j,k,e)+duds(i,j,k,e)+dudt(i,j,k,e)
                   enddo
@@ -666,14 +666,14 @@ c
 !$acc end parallel
       endif
       if (ifh2) then
-!$acc parallel num_gangs(nelt)
+!$acc parallel num_gangs(lelt)
 !$acc loop gang
-         do e=1,nelt
+         do e=1,lelt
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(ijke)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      au(i,j,k,e) = au(i,j,k,e) +
      $                  helm2(i,j,k,e)*bm1(i,j,k,e)*u(i,j,k,e)
                   enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -588,13 +588,13 @@ c
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-!$ACC PARALLEL 
 
-!$ACC LOOP COLLAPSE(4) GANG WORKER VECTOR
-!$ACC&     PRIVATE(tmpu1,tmpu2,tmpu3)
-!$ACC&     PRIVATE(ijke)
+!$acc parallel num_gangs(nelt)
+!$acc loop gang
          do e=1,nelt
+!$acc loop seq
             do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
                do j=1,ny1
                   do i=1,nx1
                      ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -602,7 +602,7 @@ c
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
-!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+!$acc loop seq private(ljke,ilke,ijle)
                      do l=1,nx1
                         ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
      $                     (e-1)*nx1*ny1*nz1
@@ -620,40 +620,33 @@ c
                   enddo
                enddo
             enddo
-         enddo
-!$ACC LOOP COLLAPSE(4) GANG VECTOR
-         do e=1,nelt
-            do k=1,nz1
-               do j=1,ny1
-                  do i=1,nx1
-                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $                  (e-1)*nx1*ny1*nz1
-                     tmp1(ijke) = helm1(ijke)*(
-     $                    + dudr(ijke)*g1m1(i,j,k,e)
-     $                    + duds(ijke)*g4m1(i,j,k,e)
-     $                    + dudt(ijke)*g5m1(i,j,k,e))
+!$acc loop seq
+         do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  tmp1(ijke) = helm1(ijke)*(
+     $                 + dudr(ijke)*g1m1(i,j,k,e)
+     $                 + duds(ijke)*g4m1(i,j,k,e)
+     $                 + dudt(ijke)*g5m1(i,j,k,e))
 
-                     tmp2(ijke) = helm1(ijke)*(
-     $                    + duds(ijke)*g2m1(i,j,k,e)
-     $                    + dudr(ijke)*g4m1(i,j,k,e)
-     $                    + dudt(ijke)*g6m1(i,j,k,e))
+                  tmp2(ijke) = helm1(ijke)*(
+     $                 + duds(ijke)*g2m1(i,j,k,e)
+     $                 + dudr(ijke)*g4m1(i,j,k,e)
+     $                 + dudt(ijke)*g6m1(i,j,k,e))
 
-                     tmp3(ijke) = helm1(ijke)*(
-     $                    + dudt(ijke)*g3m1(i,j,k,e)
-     $                    + dudr(ijke)*g5m1(i,j,k,e)
-     $                    + duds(ijke)*g6m1(i,j,k,e))
-                  enddo
+                  tmp3(ijke) = helm1(ijke)*(
+     $                 + dudt(ijke)*g3m1(i,j,k,e)
+     $                 + dudr(ijke)*g5m1(i,j,k,e)
+     $                 + duds(ijke)*g6m1(i,j,k,e))
                enddo
             enddo
          enddo
-!$ACC END PARALLEL
-
-!FIXME: Div should also include summation
-!        CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
-!$acc parallel loop collapse(4) gang worker vector
-!$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
-      do e=1,nelv
+!$acc loop seq
          do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
             do j=1,ny1
                do i=1,nx1
                   ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -661,7 +654,7 @@ c
                   tmpu1 = 0.0
                   tmpu2 = 0.0
                   tmpu3 = 0.0
-!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+!$acc loop seq private(ljke,ilke,ijle)
                   do l=1,nx1
                      ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
      $                  (e-1)*nx1*ny1*nz1
@@ -673,19 +666,15 @@ c
                      tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
                      tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
                   enddo
-!$acc end loop
                   dudr(ijke) = tmpu1
                   duds(ijke) = tmpu2
                   dudt(ijke) = tmpu3
                enddo
             enddo
          enddo
-      enddo
-!$acc end parallel loop
-
-!$ACC PARALLEL LOOP GANG VECTOR
-      do e=1,nelv
+!$acc loop seq
          do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
             do j=1,ny1
                do i=1,nx1
                   ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -695,7 +684,7 @@ c
             enddo
          enddo
       enddo
-!$ACC END PARALLEL
+!$acc end parallel
 
       endif
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -621,22 +621,30 @@ c
                enddo
             enddo
          enddo
-!$ACC LOOP GANG VECTOR
-         do i=1,ntot
-            tmp1(i) = helm1(i)*(
-     $           + dudr(i)*g1m1(i,1,1,1)
-     $           + duds(i)*g4m1(i,1,1,1)
-     $           + dudt(i)*g5m1(i,1,1,1))
+!$ACC LOOP COLLAPSE(4) GANG VECTOR
+         do e=1,nelt
+            do k=1,nz1
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmp1(ijke) = helm1(ijke)*(
+     $                    + dudr(ijke)*g1m1(i,j,k,e)
+     $                    + duds(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g5m1(i,j,k,e))
 
-            tmp2(i) = helm1(i)*(
-     $           + duds(i)*g2m1(i,1,1,1)
-     $           + dudr(i)*g4m1(i,1,1,1)
-     $           + dudt(i)*g6m1(i,1,1,1))
+                     tmp2(ijke) = helm1(ijke)*(
+     $                    + duds(ijke)*g2m1(i,j,k,e)
+     $                    + dudr(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g6m1(i,j,k,e))
 
-            tmp3(i) = helm1(i)*(
-     $           + dudt(i)*g3m1(i,1,1,1)
-     $           + dudr(i)*g5m1(i,1,1,1)
-     $           + duds(i)*g6m1(i,1,1,1))
+                     tmp3(ijke) = helm1(ijke)*(
+     $                    + dudt(ijke)*g3m1(i,j,k,e)
+     $                    + dudr(ijke)*g5m1(i,j,k,e)
+     $                    + duds(ijke)*g6m1(i,j,k,e))
+                  enddo
+               enddo
+            enddo
          enddo
 !$ACC END PARALLEL
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -613,31 +613,20 @@ c
                         tmpu2 = tmpu2 + s_dxm1(j,l)*u(i,l,k,e)
                         tmpu3 = tmpu3 + s_dxm1(k,l)*u(i,j,l,e)
                      enddo
-                     dudr(i,j,k,e) = tmpu1
-                     duds(i,j,k,e) = tmpu2
-                     dudt(i,j,k,e) = tmpu3
-                  enddo
-               enddo
-            enddo
-!$acc loop seq
-            do k=1,lz1
-!$acc loop vector tile(lx1,ly1)
-               do j=1,ly1
-                  do i=1,lx1
                      tmp1(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + dudr(i,j,k,e)*g1m1(i,j,k,e)
-     $                    + duds(i,j,k,e)*g4m1(i,j,k,e)
-     $                    + dudt(i,j,k,e)*g5m1(i,j,k,e))
+     $                    + tmpu1*g1m1(i,j,k,e)
+     $                    + tmpu2*g4m1(i,j,k,e)
+     $                    + tmpu3*g5m1(i,j,k,e))
 
                      tmp2(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + duds(i,j,k,e)*g2m1(i,j,k,e)
-     $                    + dudr(i,j,k,e)*g4m1(i,j,k,e)
-     $                    + dudt(i,j,k,e)*g6m1(i,j,k,e))
+     $                    + tmpu2*g2m1(i,j,k,e)
+     $                    + tmpu1*g4m1(i,j,k,e)
+     $                    + tmpu3*g6m1(i,j,k,e))
 
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + dudt(i,j,k,e)*g3m1(i,j,k,e)
-     $                    + dudr(i,j,k,e)*g5m1(i,j,k,e)
-     $                    + duds(i,j,k,e)*g6m1(i,j,k,e))
+     $                    + tmpu3*g3m1(i,j,k,e)
+     $                    + tmpu1*g5m1(i,j,k,e)
+     $                    + tmpu2*g6m1(i,j,k,e))
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -558,6 +558,8 @@ c
       real           duax  (lx1)
       real           ysm1  (lx1)
 
+      real s_dxm1(lx1+1,ly1)
+
       integer e
       real tmpu1,tmpu2,tmpu3
 
@@ -588,8 +590,15 @@ c
          call exitt()
       else
 !$acc parallel num_gangs(lelt)
-!$acc loop gang
+!$acc loop gang private(s_dxm1)
          do e=1,lelt
+!$acc loop vector tile(lx1,ly1)
+            do j=1,ly1
+               do i=1,lx1
+                  s_dxm1(i,j) = dxm1(i,j)
+               enddo
+            enddo
+!$acc cache(s_dxm1)
 !$acc loop seq
             do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
@@ -600,9 +609,9 @@ c
                      tmpu3 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + dxm1(i,l)*u(l,j,k,e)
-                        tmpu2 = tmpu2 + dxm1(j,l)*u(i,l,k,e)
-                        tmpu3 = tmpu3 + dxm1(k,l)*u(i,j,l,e)
+                        tmpu1 = tmpu1 + s_dxm1(i,l)*u(l,j,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(j,l)*u(i,l,k,e)
+                        tmpu3 = tmpu3 + s_dxm1(k,l)*u(i,j,l,e)
                      enddo
                      dudr(i,j,k,e) = tmpu1
                      duds(i,j,k,e) = tmpu2
@@ -642,9 +651,9 @@ c
                      tmpu3 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(l,j,k,e)
-                        tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(i,l,k,e)
-                        tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(i,j,l,e)
+                        tmpu1 = tmpu1 + s_dxm1(l,i)*tmp1(l,j,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
                      dudr(i,j,k,e) = tmpu1
                      duds(i,j,k,e) = tmpu2


### PR DESCRIPTION
The axhelm ACC kernel now utilizes shared memory (via `!$ acc cache` declarations) to optimize bandwidth.  These improvements lead 2x FLOP/s for this kernel in the singlerod test case on both pascal and volta GPUs.  