### PR TITLE
OpenACC shared memory in hsmg_do_fast

### DIFF
--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -560,6 +560,7 @@ c
 
       real s_dxm1(lx1+1,ly1)
       real s_u_ur(lx1+1,ly1)
+      real s_us(lx1+1,ly1)
 
       integer e
       real tmpu1,tmpu2,tmpu3
@@ -591,9 +592,9 @@ c
          call exitt()
       else
 !$acc parallel num_gangs(lelt)
-!$acc loop gang private(s_dxm1,s_u_ur)
+!$acc loop gang private(s_dxm1,s_u_ur,s_us)
          do e=1,lelt
-!$acc cache(s_dxm1,s_u_ur)
+!$acc cache(s_dxm1,s_u_ur,s_us)
 !$acc loop vector tile(lx1,ly1)
             do j=1,ly1
                do i=1,lx1
@@ -624,11 +625,10 @@ c
      $                    + tmpu1*g1m1(i,j,k,e)
      $                    + tmpu2*g4m1(i,j,k,e)
      $                    + tmpu3*g5m1(i,j,k,e))
-                     tmp2(i,j,k,e) = helm1(i,j,k,e)*(
+                     s_us(i,j) = helm1(i,j,k,e)*(
      $                    + tmpu2*g2m1(i,j,k,e)
      $                    + tmpu1*g4m1(i,j,k,e)
      $                    + tmpu3*g6m1(i,j,k,e))
-
 
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu3*g3m1(i,j,k,e)
@@ -645,7 +645,7 @@ c
 !$acc loop seq
                      do l=1,lx1
                         tmpu1 = tmpu1 + s_dxm1(l,i)*s_u_ur(l,j)
-                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*s_us(i,l)
                      enddo
                      au(i,j,k,e) = tmpu1 + tmpu2
                   enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -555,12 +555,8 @@ c
      $ ,             tmp2  (lx1*ly1*lz1*lelt)
      $ ,             tmp3  (lx1*ly1*lz1*lelt)
 
-      real           tm1   (lx1*ly1*lz1)
-      real           tm2   (lx1*ly1*lz1)
-      real           tm3   (lx1*ly1*lz1)
       real           duax  (lx1)
       real           ysm1  (lx1)
-      equivalence    (dudr,tm1),(duds,tm2),(dudt,tm3)
 
       integer e
       real tmpu1,tmpu2,tmpu3
@@ -645,11 +641,11 @@ c
 !$ACC END PARALLEL
 
 !FIXME: Div should also include summation
-         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,tm1,tm2,tm3)
+         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
 
 !$ACC PARALLEL LOOP GANG VECTOR
          do i=1,ntot
-            au(i) = tm1(i)+tm2(i)+tm3(i)
+            au(i) = dudr(i)+duds(i)+dudt(i)
          enddo
 !$ACC END PARALLEL
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -653,40 +653,48 @@ c
 !$acc parallel loop collapse(4) gang worker vector
 !$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
       do e=1,nelv
-      do k=1,nz1
-      do j=1,ny1
-      do i=1,nx1
-         ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $      (e-1)*nx1*ny1*nz1
-         tmpu1 = 0.0
-         tmpu2 = 0.0
-         tmpu3 = 0.0
+         do k=1,nz1
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  tmpu1 = 0.0
+                  tmpu2 = 0.0
+                  tmpu3 = 0.0
 !$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
-         do l=1,nx1
-            ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
-     $         (e-1)*nx1*ny1*nz1
-            tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
-            tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
-            tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                  do l=1,nx1
+                     ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $                  (e-1)*nx1*ny1*nz1
+                     tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+                     tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+                     tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                  enddo
+!$acc end loop
+                  dudr(ijke) = tmpu1
+                  duds(ijke) = tmpu2
+                  dudt(ijke) = tmpu3
+               enddo
+            enddo
          enddo
-!$acc    end loop
-         dudr(ijke) = tmpu1
-         duds(ijke) = tmpu2
-         dudt(ijke) = tmpu3
-      enddo
-      enddo
-      enddo
       enddo
 !$acc end parallel loop
 
 !$ACC PARALLEL LOOP GANG VECTOR
-         do i=1,ntot
-            au(i) = dudr(i)+duds(i)+dudt(i)
+      do e=1,nelv
+         do k=1,nz1
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+               enddo
+            enddo
          enddo
+      enddo
 !$ACC END PARALLEL
 
       endif

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -582,13 +582,11 @@ c
 !$ACC DATA CREATE(dudr,duds,dudt,tmp1,tmp2,tmp3)
 !$ACC& PRESENT(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1)
 !$ACC& PRESENT(dxm1,dxtm1,au,u,helm1,helm2)
-
       if (ndim.eq.2) then
          if(nid.eq.0) write(6,*)
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-
 !$acc parallel num_gangs(nelt)
 !$acc loop gang
          do e=1,nelt
@@ -621,82 +619,91 @@ c
                enddo
             enddo
 !$acc loop seq
-         do k=1,nz1
+            do k=1,nz1
 !$acc loop vector tile(nx1,ny1) private(ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  tmp1(ijke) = helm1(ijke)*(
-     $                 + dudr(ijke)*g1m1(i,j,k,e)
-     $                 + duds(ijke)*g4m1(i,j,k,e)
-     $                 + dudt(ijke)*g5m1(i,j,k,e))
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmp1(ijke) = helm1(ijke)*(
+     $                    + dudr(ijke)*g1m1(i,j,k,e)
+     $                    + duds(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g5m1(i,j,k,e))
 
-                  tmp2(ijke) = helm1(ijke)*(
-     $                 + duds(ijke)*g2m1(i,j,k,e)
-     $                 + dudr(ijke)*g4m1(i,j,k,e)
-     $                 + dudt(ijke)*g6m1(i,j,k,e))
+                     tmp2(ijke) = helm1(ijke)*(
+     $                    + duds(ijke)*g2m1(i,j,k,e)
+     $                    + dudr(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g6m1(i,j,k,e))
 
-                  tmp3(ijke) = helm1(ijke)*(
-     $                 + dudt(ijke)*g3m1(i,j,k,e)
-     $                 + dudr(ijke)*g5m1(i,j,k,e)
-     $                 + duds(ijke)*g6m1(i,j,k,e))
-               enddo
-            enddo
-         enddo
-!$acc loop seq
-         do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  tmpu1 = 0.0
-                  tmpu2 = 0.0
-                  tmpu3 = 0.0
-!$acc loop seq private(ljke,ilke,ijle)
-                  do l=1,nx1
-                     ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
-     $                  (e-1)*nx1*ny1*nz1
-                     tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
-                     tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
-                     tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                     tmp3(ijke) = helm1(ijke)*(
+     $                    + dudt(ijke)*g3m1(i,j,k,e)
+     $                    + dudr(ijke)*g5m1(i,j,k,e)
+     $                    + duds(ijke)*g6m1(i,j,k,e))
                   enddo
-                  dudr(ijke) = tmpu1
-                  duds(ijke) = tmpu2
-                  dudt(ijke) = tmpu3
                enddo
             enddo
-         enddo
 !$acc loop seq
-         do k=1,nz1
+            do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmpu1 = 0.0
+                     tmpu2 = 0.0
+                     tmpu3 = 0.0
+!$acc loop seq private(ljke,ilke,ijle)
+                     do l=1,nx1
+                        ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $                     (e-1)*nx1*ny1*nz1
+                        tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+                        tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+                        tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+                     enddo
+                     dudr(ijke) = tmpu1
+                     duds(ijke) = tmpu2
+                     dudt(ijke) = tmpu3
+                  enddo
+               enddo
+            enddo
+!$acc loop seq
+            do k=1,nz1
 !$acc loop vector tile(nx1,ny1) private(ijke)
-            do j=1,ny1
-               do i=1,nx1
-                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $               (e-1)*nx1*ny1*nz1
-                  au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     au(ijke) = dudr(ijke)+duds(ijke)+dudt(ijke)
+                  enddo
                enddo
             enddo
          enddo
-      enddo
 !$acc end parallel
-
       endif
-
       if (ifh2) then
-!$ACC PARALLEL LOOP GANG VECTOR
-         do i=1,ntot
-            au(i) = au(i) + helm2(i)*bm1(i,1,1,1)*u(i)
+!$acc parallel num_gangs(nelt)
+!$acc loop gang
+         do e=1,nelt
+!$acc loop seq
+            do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     au(ijke) = au(ijke) +
+     $                  helm2(ijke)*bm1(i,j,k,e)*u(ijke)
+                  enddo
+               enddo
+            enddo
          enddo
-!$ACC END PARALLEL
+!$acc end parallel
       endif
-
-!$ACC END DATA
+!$acc end data
  
 c     if axisymmetric, add a diagonal term in the radial direction (isd=2)
  

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -646,18 +646,18 @@ c
 !$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
                do j=1,ly1
                   do i=1,lx1
-                     tmpu1 = 0.0
-                     tmpu2 = 0.0
-                     tmpu3 = 0.0
+                     dudr(i,j,k,e) = 0.0
+                     duds(i,j,k,e) = 0.0
+                     dudt(i,j,k,e) = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + s_dxm1(l,i)*tmp1(l,j,k,e)
-                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
-                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
+                        dudr(i,j,k,e) = dudr(i,j,k,e) 
+     $                     + s_dxm1(l,i)*tmp1(l,j,k,e)
+                        duds(i,j,k,e) = duds(i,j,k,e) 
+     $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        dudt(i,j,k,e) = dudt(i,j,k,e) 
+     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
-                     dudr(i,j,k,e) = tmpu1
-                     duds(i,j,k,e) = tmpu2
-                     dudt(i,j,k,e) = tmpu3
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -617,36 +617,32 @@ c
      $                    + tmpu1*g1m1(i,j,k,e)
      $                    + tmpu2*g4m1(i,j,k,e)
      $                    + tmpu3*g5m1(i,j,k,e))
-
                      tmp2(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu2*g2m1(i,j,k,e)
      $                    + tmpu1*g4m1(i,j,k,e)
      $                    + tmpu3*g6m1(i,j,k,e))
 
+
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + tmpu3*g3m1(i,j,k,e)
      $                    + tmpu1*g5m1(i,j,k,e)
      $                    + tmpu2*g6m1(i,j,k,e))
+
                   enddo
                enddo
-            enddo
-!$acc loop seq
-            do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
                      dudr(i,j,k,e) = 0.0
                      duds(i,j,k,e) = 0.0
-                     dudt(i,j,k,e) = 0.0
 !$acc loop seq
                      do l=1,lx1
                         dudr(i,j,k,e) = dudr(i,j,k,e) 
      $                     + s_dxm1(l,i)*tmp1(l,j,k,e)
                         duds(i,j,k,e) = duds(i,j,k,e) 
      $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
-                        dudt(i,j,k,e) = dudt(i,j,k,e) 
-     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
+                     au(i,j,k,e) = dudr(i,j,k,e) + duds(i,j,k,e)
                   enddo
                enddo
             enddo
@@ -655,8 +651,12 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     au(i,j,k,e) =
-     $                    dudr(i,j,k,e)+duds(i,j,k,e)+dudt(i,j,k,e)
+                     dudt(i,j,k,e) = 0.0
+                     do l=1,lx1
+                        dudt(i,j,k,e) = dudt(i,j,k,e) 
+     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
+                     enddo
+                     au(i,j,k,e) = au(i,j,k,e) + dudt(i,j,k,e)
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -640,16 +640,14 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     dudr(i,j,k,e) = 0.0
-                     duds(i,j,k,e) = 0.0
+                     tmpu1 = 0.0
+                     tmpu2 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        dudr(i,j,k,e) = dudr(i,j,k,e) 
-     $                     + s_dxm1(l,i)*s_u_ur(l,j)
-                        duds(i,j,k,e) = duds(i,j,k,e) 
-     $                     + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu1 = tmpu1 + s_dxm1(l,i)*s_u_ur(l,j)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
                      enddo
-                     au(i,j,k,e) = dudr(i,j,k,e) + duds(i,j,k,e)
+                     au(i,j,k,e) = tmpu1 + tmpu2
                   enddo
                enddo
             enddo
@@ -658,12 +656,11 @@ c
 !$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
-                     dudt(i,j,k,e) = 0.0
+                     tmpu3 = 0.0
                      do l=1,lx1
-                        dudt(i,j,k,e) = dudt(i,j,k,e) 
-     $                     + s_dxm1(l,k)*tmp3(i,j,l,e)
+                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
-                     au(i,j,k,e) = au(i,j,k,e) + dudt(i,j,k,e)
+                     au(i,j,k,e) = au(i,j,k,e) + tmpu3
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -641,7 +641,39 @@ c
 !$ACC END PARALLEL
 
 !FIXME: Div should also include summation
-         CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
+!        CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
+!$acc parallel loop collapse(4) gang worker vector
+!$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
+      do e=1,nelv
+      do k=1,nz1
+      do j=1,ny1
+      do i=1,nx1
+         ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $      (e-1)*nx1*ny1*nz1
+         tmpu1 = 0.0
+         tmpu2 = 0.0
+         tmpu3 = 0.0
+!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+         do l=1,nx1
+            ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            ilke = i + (l-1)*nx1 + (k-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            ijle = i + (j-1)*nx1 + (l-1)*nx1*ny1 + 
+     $         (e-1)*nx1*ny1*nz1
+            tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(ljke)
+            tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
+            tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
+         enddo
+!$acc    end loop
+         dudr(ijke) = tmpu1
+         duds(ijke) = tmpu2
+         dudt(ijke) = tmpu3
+      enddo
+      enddo
+      enddo
+      enddo
+!$acc end parallel loop
 
 !$ACC PARALLEL LOOP GANG VECTOR
          do i=1,ntot

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -583,7 +583,7 @@ c
 
 !$ACC DATA CREATE(dudr,duds,dudt,tmp1,tmp2,tmp3)
 !$ACC& PRESENT(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1)
-!$ACC& PRESENT(dxm1,dxtm1,au,u,helm1,helm2)
+!$ACC& PRESENT(dxm1,au,u,helm1,helm2)
       if (ndim.eq.2) then
          if(nid.eq.0) write(6,*)
      $        '2D Not currently implemented on for OpenACC'
@@ -592,13 +592,13 @@ c
 !$acc parallel num_gangs(lelt)
 !$acc loop gang private(s_dxm1)
          do e=1,lelt
+!$acc cache(s_dxm1)
 !$acc loop vector tile(lx1,ly1)
             do j=1,ly1
                do i=1,lx1
                   s_dxm1(i,j) = dxm1(i,j)
                enddo
             enddo
-!$acc cache(s_dxm1)
 !$acc loop seq
             do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
@@ -632,7 +632,7 @@ c
             enddo
 !$acc loop seq
             do k=1,lz1
-!$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
+!$acc loop vector tile(lx1,ly1)
                do j=1,ly1
                   do i=1,lx1
                      dudr(i,j,k,e) = 0.0

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -587,19 +587,19 @@ c
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-!$acc parallel num_gangs(nelt)
+!$acc parallel num_gangs(lelt)
 !$acc loop gang
-         do e=1,nelt
+         do e=1,lelt
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
 !$acc loop seq
-                     do l=1,nx1
+                     do l=1,lx1
                         tmpu1 = tmpu1 + dxm1(i,l)*u(l,j,k,e)
                         tmpu2 = tmpu2 + dxm1(j,l)*u(i,l,k,e)
                         tmpu3 = tmpu3 + dxm1(k,l)*u(i,j,l,e)
@@ -611,10 +611,10 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      tmp1(i,j,k,e) = helm1(i,j,k,e)*(
      $                    + dudr(i,j,k,e)*g1m1(i,j,k,e)
      $                    + duds(i,j,k,e)*g4m1(i,j,k,e)
@@ -633,15 +633,15 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1) private(tmpu1,tmpu2,tmpu3)
+               do j=1,ly1
+                  do i=1,lx1
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
 !$acc loop seq
-                     do l=1,nx1
+                     do l=1,lx1
                         tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(l,j,k,e)
                         tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(i,l,k,e)
                         tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(i,j,l,e)
@@ -653,10 +653,10 @@ c
                enddo
             enddo
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(ijke)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      au(i,j,k,e) =
      $                    dudr(i,j,k,e)+duds(i,j,k,e)+dudt(i,j,k,e)
                   enddo
@@ -666,14 +666,14 @@ c
 !$acc end parallel
       endif
       if (ifh2) then
-!$acc parallel num_gangs(nelt)
+!$acc parallel num_gangs(lelt)
 !$acc loop gang
-         do e=1,nelt
+         do e=1,lelt
 !$acc loop seq
-            do k=1,nz1
-!$acc loop vector tile(nx1,ny1) private(ijke)
-               do j=1,ny1
-                  do i=1,nx1
+            do k=1,lz1
+!$acc loop vector tile(lx1,ly1)
+               do j=1,ly1
+                  do i=1,lx1
                      au(i,j,k,e) = au(i,j,k,e) +
      $                  helm2(i,j,k,e)*bm1(i,j,k,e)*u(i,j,k,e)
                   enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -588,13 +588,13 @@ c
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
       else
-!$ACC PARALLEL 
 
-!$ACC LOOP COLLAPSE(4) GANG WORKER VECTOR
-!$ACC&     PRIVATE(tmpu1,tmpu2,tmpu3)
-!$ACC&     PRIVATE(ijke)
+!$acc parallel num_gangs(nelt)
+!$acc loop gang
          do e=1,nelt
+!$acc loop seq
             do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
                do j=1,ny1
                   do i=1,nx1
                      ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -602,7 +602,7 @@ c
                      tmpu1 = 0.0
                      tmpu2 = 0.0
                      tmpu3 = 0.0
-!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+!$acc loop seq private(ljke,ilke,ijle)
                      do l=1,nx1
                         ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
      $                     (e-1)*nx1*ny1*nz1
@@ -620,40 +620,33 @@ c
                   enddo
                enddo
             enddo
-         enddo
-!$ACC LOOP COLLAPSE(4) GANG VECTOR
-         do e=1,nelt
-            do k=1,nz1
-               do j=1,ny1
-                  do i=1,nx1
-                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
-     $                  (e-1)*nx1*ny1*nz1
-                     tmp1(ijke) = helm1(ijke)*(
-     $                    + dudr(ijke)*g1m1(i,j,k,e)
-     $                    + duds(ijke)*g4m1(i,j,k,e)
-     $                    + dudt(ijke)*g5m1(i,j,k,e))
+!$acc loop seq
+         do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
+            do j=1,ny1
+               do i=1,nx1
+                  ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $               (e-1)*nx1*ny1*nz1
+                  tmp1(ijke) = helm1(ijke)*(
+     $                 + dudr(ijke)*g1m1(i,j,k,e)
+     $                 + duds(ijke)*g4m1(i,j,k,e)
+     $                 + dudt(ijke)*g5m1(i,j,k,e))
 
-                     tmp2(ijke) = helm1(ijke)*(
-     $                    + duds(ijke)*g2m1(i,j,k,e)
-     $                    + dudr(ijke)*g4m1(i,j,k,e)
-     $                    + dudt(ijke)*g6m1(i,j,k,e))
+                  tmp2(ijke) = helm1(ijke)*(
+     $                 + duds(ijke)*g2m1(i,j,k,e)
+     $                 + dudr(ijke)*g4m1(i,j,k,e)
+     $                 + dudt(ijke)*g6m1(i,j,k,e))
 
-                     tmp3(ijke) = helm1(ijke)*(
-     $                    + dudt(ijke)*g3m1(i,j,k,e)
-     $                    + dudr(ijke)*g5m1(i,j,k,e)
-     $                    + duds(ijke)*g6m1(i,j,k,e))
-                  enddo
+                  tmp3(ijke) = helm1(ijke)*(
+     $                 + dudt(ijke)*g3m1(i,j,k,e)
+     $                 + dudr(ijke)*g5m1(i,j,k,e)
+     $                 + duds(ijke)*g6m1(i,j,k,e))
                enddo
             enddo
          enddo
-!$ACC END PARALLEL
-
-!FIXME: Div should also include summation
-!        CALL global_div3(dxtm1,tmp1,tmp2,tmp3,dudr,duds,dudt)
-!$acc parallel loop collapse(4) gang worker vector
-!$acc&    private(tmpu1,tmpu2,tmpu3,ijke)
-      do e=1,nelv
+!$acc loop seq
          do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(tmpu1,tmpu2,tmpu3,ijke)
             do j=1,ny1
                do i=1,nx1
                   ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -661,7 +654,7 @@ c
                   tmpu1 = 0.0
                   tmpu2 = 0.0
                   tmpu3 = 0.0
-!$ACC LOOP SEQ PRIVATE(ljke,ilke,ijle)
+!$acc loop seq private(ljke,ilke,ijle)
                   do l=1,nx1
                      ljke = l + (j-1)*nx1 + (k-1)*nx1*ny1 + 
      $                  (e-1)*nx1*ny1*nz1
@@ -673,19 +666,15 @@ c
                      tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(ilke)
                      tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(ijle)
                   enddo
-!$acc end loop
                   dudr(ijke) = tmpu1
                   duds(ijke) = tmpu2
                   dudt(ijke) = tmpu3
                enddo
             enddo
          enddo
-      enddo
-!$acc end parallel loop
-
-!$ACC PARALLEL LOOP GANG VECTOR
-      do e=1,nelv
+!$acc loop seq
          do k=1,nz1
+!$acc loop vector tile(nx1,ny1) private(ijke)
             do j=1,ny1
                do i=1,nx1
                   ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
@@ -695,7 +684,7 @@ c
             enddo
          enddo
       enddo
-!$ACC END PARALLEL
+!$acc end parallel
 
       endif
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -621,22 +621,30 @@ c
                enddo
             enddo
          enddo
-!$ACC LOOP GANG VECTOR
-         do i=1,ntot
-            tmp1(i) = helm1(i)*(
-     $           + dudr(i)*g1m1(i,1,1,1)
-     $           + duds(i)*g4m1(i,1,1,1)
-     $           + dudt(i)*g5m1(i,1,1,1))
+!$ACC LOOP COLLAPSE(4) GANG VECTOR
+         do e=1,nelt
+            do k=1,nz1
+               do j=1,ny1
+                  do i=1,nx1
+                     ijke = i + (j-1)*nx1 + (k-1)*nx1*ny1 +
+     $                  (e-1)*nx1*ny1*nz1
+                     tmp1(ijke) = helm1(ijke)*(
+     $                    + dudr(ijke)*g1m1(i,j,k,e)
+     $                    + duds(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g5m1(i,j,k,e))
 
-            tmp2(i) = helm1(i)*(
-     $           + duds(i)*g2m1(i,1,1,1)
-     $           + dudr(i)*g4m1(i,1,1,1)
-     $           + dudt(i)*g6m1(i,1,1,1))
+                     tmp2(ijke) = helm1(ijke)*(
+     $                    + duds(ijke)*g2m1(i,j,k,e)
+     $                    + dudr(ijke)*g4m1(i,j,k,e)
+     $                    + dudt(ijke)*g6m1(i,j,k,e))
 
-            tmp3(i) = helm1(i)*(
-     $           + dudt(i)*g3m1(i,1,1,1)
-     $           + dudr(i)*g5m1(i,1,1,1)
-     $           + duds(i)*g6m1(i,1,1,1))
+                     tmp3(ijke) = helm1(ijke)*(
+     $                    + dudt(ijke)*g3m1(i,j,k,e)
+     $                    + dudr(ijke)*g5m1(i,j,k,e)
+     $                    + duds(ijke)*g6m1(i,j,k,e))
+                  enddo
+               enddo
+            enddo
          enddo
 !$ACC END PARALLEL
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -613,31 +613,20 @@ c
                         tmpu2 = tmpu2 + s_dxm1(j,l)*u(i,l,k,e)
                         tmpu3 = tmpu3 + s_dxm1(k,l)*u(i,j,l,e)
                      enddo
-                     dudr(i,j,k,e) = tmpu1
-                     duds(i,j,k,e) = tmpu2
-                     dudt(i,j,k,e) = tmpu3
-                  enddo
-               enddo
-            enddo
-!$acc loop seq
-            do k=1,lz1
-!$acc loop vector tile(lx1,ly1)
-               do j=1,ly1
-                  do i=1,lx1
                      tmp1(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + dudr(i,j,k,e)*g1m1(i,j,k,e)
-     $                    + duds(i,j,k,e)*g4m1(i,j,k,e)
-     $                    + dudt(i,j,k,e)*g5m1(i,j,k,e))
+     $                    + tmpu1*g1m1(i,j,k,e)
+     $                    + tmpu2*g4m1(i,j,k,e)
+     $                    + tmpu3*g5m1(i,j,k,e))
 
                      tmp2(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + duds(i,j,k,e)*g2m1(i,j,k,e)
-     $                    + dudr(i,j,k,e)*g4m1(i,j,k,e)
-     $                    + dudt(i,j,k,e)*g6m1(i,j,k,e))
+     $                    + tmpu2*g2m1(i,j,k,e)
+     $                    + tmpu1*g4m1(i,j,k,e)
+     $                    + tmpu3*g6m1(i,j,k,e))
 
                      tmp3(i,j,k,e) = helm1(i,j,k,e)*(
-     $                    + dudt(i,j,k,e)*g3m1(i,j,k,e)
-     $                    + dudr(i,j,k,e)*g5m1(i,j,k,e)
-     $                    + duds(i,j,k,e)*g6m1(i,j,k,e))
+     $                    + tmpu3*g3m1(i,j,k,e)
+     $                    + tmpu1*g5m1(i,j,k,e)
+     $                    + tmpu2*g6m1(i,j,k,e))
                   enddo
                enddo
             enddo

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -558,6 +558,8 @@ c
       real           duax  (lx1)
       real           ysm1  (lx1)
 
+      real s_dxm1(lx1+1,ly1)
+
       integer e
       real tmpu1,tmpu2,tmpu3
 
@@ -588,8 +590,15 @@ c
          call exitt()
       else
 !$acc parallel num_gangs(lelt)
-!$acc loop gang
+!$acc loop gang private(s_dxm1)
          do e=1,lelt
+!$acc loop vector tile(lx1,ly1)
+            do j=1,ly1
+               do i=1,lx1
+                  s_dxm1(i,j) = dxm1(i,j)
+               enddo
+            enddo
+!$acc cache(s_dxm1)
 !$acc loop seq
             do k=1,lz1
 !$acc loop vector tile(lx1,ly1)
@@ -600,9 +609,9 @@ c
                      tmpu3 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + dxm1(i,l)*u(l,j,k,e)
-                        tmpu2 = tmpu2 + dxm1(j,l)*u(i,l,k,e)
-                        tmpu3 = tmpu3 + dxm1(k,l)*u(i,j,l,e)
+                        tmpu1 = tmpu1 + s_dxm1(i,l)*u(l,j,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(j,l)*u(i,l,k,e)
+                        tmpu3 = tmpu3 + s_dxm1(k,l)*u(i,j,l,e)
                      enddo
                      dudr(i,j,k,e) = tmpu1
                      duds(i,j,k,e) = tmpu2
@@ -642,9 +651,9 @@ c
                      tmpu3 = 0.0
 !$acc loop seq
                      do l=1,lx1
-                        tmpu1 = tmpu1 + dxtm1(i,l)*tmp1(l,j,k,e)
-                        tmpu2 = tmpu2 + dxtm1(j,l)*tmp2(i,l,k,e)
-                        tmpu3 = tmpu3 + dxtm1(k,l)*tmp3(i,j,l,e)
+                        tmpu1 = tmpu1 + s_dxm1(l,i)*tmp1(l,j,k,e)
+                        tmpu2 = tmpu2 + s_dxm1(l,j)*tmp2(i,l,k,e)
+                        tmpu3 = tmpu3 + s_dxm1(l,k)*tmp3(i,j,l,e)
                      enddo
                      dudr(i,j,k,e) = tmpu1
                      duds(i,j,k,e) = tmpu2

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -1061,10 +1061,20 @@ c     clobbers r
       include 'HSMG'
 
 #ifdef _OPENACC
-      call hsmg_do_fast_acc(e,r,
-     $     mg_fast_s(mg_fast_s_index(l,mg_fld)),
-     $     mg_fast_d(mg_fast_d_index(l,mg_fld)),
-     $     mg_nh(l)+2)
+      if (mg_nh(l)+2 .eq. 6 .and. ldim .eq. 3) then
+         call hsmg_do_fast_acc_nl6_ndim3(e,r,
+     $         mg_fast_s(mg_fast_s_index(l,mg_fld)),
+     $         mg_fast_d(mg_fast_d_index(l,mg_fld)))
+      elseif (mg_nh(l)+2 .eq. 10 .and. ldim .eq. 3) then
+         call hsmg_do_fast_acc_nl10_ndim3(e,r,
+     $         mg_fast_s(mg_fast_s_index(l,mg_fld)),
+     $         mg_fast_d(mg_fast_d_index(l,mg_fld)))
+      else
+         call hsmg_do_fast_acc(e,r,
+     $         mg_fast_s(mg_fast_s_index(l,mg_fld)),
+     $         mg_fast_d(mg_fast_d_index(l,mg_fld)),
+     $         mg_nh(l)+2)
+      endif
 #else
       call hsmg_do_fast    (e,r,
      $      mg_fast_s(mg_fast_s_index(l,mg_fld)),
@@ -1245,6 +1255,328 @@ c     clobbers r
       return
       end
 
+c-----------------------------------------------------------------------
+      subroutine hsmg_do_fast_acc_nl6_ndim3(e,r,s,d)
+      include 'SIZE'
+      real e(216,nelt)
+      real r(216,nelt)
+      real s(36,2,ndim,nelt)
+      real d(216,nelt)
+
+      integer ie,nn,i,j,k,l,i0,j0,k0,je,nu,nv,lwk
+      real tmp
+
+      real work(256), work2(256)
+      real r_s(256)
+      real s_s1(64,2)
+      real s_s2(64,2)
+      real s_s3(64,2)
+
+!$ACC DATA COPY(e,r,s,d)
+!$ACC PARALLEL NUM_GANGS(nelt) VECTOR_LENGTH(256)
+!$ACC LOOP GANG PRIVATE(work,work2,r_s,s_s1,s_s2,s_s3)
+         do ie=1,nelt
+!$ACC CACHE(r_s,work,work2,s_s1,s_s2,s_s3)
+!$ACC LOOP COLLAPSE(3) VECTOR
+            do k=1,6
+               do j=1,6
+                  do l=1,6
+                     ljk = l + 6*(j-1) + 36*(k-1)
+                     klj = k + 6*(l-1) + 36*(j-1)
+                     r_s(ljk) = r(klj,ie)
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP VECTOR
+            do k=1,216
+               work(k) = 0.0
+               work2(k) = 0.0
+            enddo
+!$ACC LOOP COLLAPSE(3) VECTOR
+            do l=1,2
+               do j=1,6
+                  do i=1,6
+                     ij = i + 6*(j-1)
+                     ji = j + 6*(i-1)
+                     s_s1(ij,l) = s(ij,l,1,ie)
+                     s_s2(ji,l) = s(ij,l,2,ie)
+                     s_s3(ji,l) = s(ij,l,3,ie)
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,6
+                  do l=1,6
+                     do i=1,6
+                        ilj = i + 6*(l-1) + 36*(j-1)
+                        ik = i + 6*(k-1)
+                        ljk = l + 6*(j-1) + 36*(k-1)
+                        ! inner/outer
+                        work(ilj) = work(ilj) + s_s1(ik,2) * r_s(ljk)
+                     enddo
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,6
+                  do j=1,6
+                     do l=1,6
+                        lji = l + 6*(j-1) + 36*(i-1)
+                        lki = l + 6*(k-1) + 36*(i-1)
+                        jk = j + 6*(k-1)
+                        ! outer/inner
+                        work2(lji) = work2(lji) + work(lki)*s_s2(jk,1)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP VECTOR
+            do k=1,216
+               r_s(k) = 0.0
+               work(k) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,6
+                  do l=1,6
+                     do i=1,6
+                        ilj = i + 6*(l-1) + 36*(j-1)
+                        ilk = i + 6*(l-1) + 36*(k-1)
+                        jk  = j + 6*(k-1)
+                        ! outer/innner
+                        r_s(ilj) = 
+     &  r_s(ilj) + d(ilj,ie)*work2(ilk)*s_s3(jk,1)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do l=1,6
+                  do j=1,6
+                     do i=1,6
+                        ijl = i + 6*(j-1) + 36*(l-1)
+                        ik = i + 6*(k-1)
+                        kjl = k + 6*(j-1) + 36*(l-1)
+                        ! inner/outer
+                        work(ijl) = work(ijl) + s_s1(ik,1) * r_s(kjl)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP VECTOR
+            do k=1,216
+               work2(k) = 0.0
+               e(k,ie) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,6
+                  do j=1,6
+                     do l=1,6
+                        lji = l + 6*(j-1) + 36*(i-1)
+                        lki = l + 6*(k-1) + 36*(i-1)
+                        jk = j + 6*(k-1)
+                        ! outer/inner
+                        work2(lji) = 
+     &  work2(lji) + work(lki)*s_s2(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,6
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,6
+                  do l=1,6
+                     do i=1,6
+                        ilj = i + 6*(l-1) + 36*(j-1)
+                        ilk = i + 6*(l-1) + 36*(k-1)
+                        jk = j + 6*(k-1)
+                        ! outer/inner
+                        e(ilj,ie) = 
+     &  e(ilj,ie) + work2(ilk)*s_s3(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
+         enddo
+!$ACC END PARALLEL
+!$ACC END DATA
+
+      return
+      end
+c----------------------------------------------------------------------
+      subroutine hsmg_do_fast_acc_nl10_ndim3(e,r,s,d)
+      include 'SIZE'
+      real e(1000,nelt)
+      real r(1000,nelt)
+      real s(100,2,3,nelt)
+      real d(1000,nelt)
+
+      integer ie,nn,i,j,k,l,i0,j0,k0,je,nu,nv,lwk
+
+      real work(1024), work2(1024)
+      real r_s(1024)
+      real s_s1(128,2)
+      real s_s2(128,2)
+      real s_s3(128,2)
+
+!$ACC DATA COPY(e,r,s,d)
+!$ACC PARALLEL NUM_GANGS(nelt) VECTOR_LENGTH(1024)
+!$ACC LOOP GANG PRIVATE(work,work2,r_s,s_s1,s_s2,s_s3)
+         do ie=1,nelt
+!$ACC CACHE(r_s,work,work2,s_s1,s_s2,s_s3)
+!$ACC LOOP COLLAPSE(3) VECTOR
+            do k=1,10
+               do j=1,10
+                  do l=1,10
+                     ljk = l + 10*(j-1) + 100*(k-1)
+                     klj = k + 10*(l-1) + 100*(j-1)
+                     r_s(ljk) = r(klj,ie)
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP VECTOR
+            do k=1,1000
+               work(k) = 0.0
+               work2(k) = 0.0
+            enddo
+!$ACC LOOP COLLAPSE(3) VECTOR
+            do l=1,2
+               do j=1,10
+                  do i=1,10
+                     ij = i + 10*(j-1)
+                     ji = j + 10*(i-1)
+                     s_s1(ij,l) = s(ij,l,1,ie)
+                     s_s2(ji,l) = s(ij,l,2,ie)
+                     s_s3(ji,l) = s(ij,l,3,ie)
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,10
+                  do l=1,10
+                     do i=1,10
+                        ilj = i + 10*(l-1) + 100*(j-1)
+                        ik = i + 10*(k-1)
+                        ljk = l + 10*(j-1) + 100*(k-1)
+                        ! inner/outer
+                        work(ilj) = work(ilj) + s_s1(ik,2) * r_s(ljk)
+                     enddo
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,10
+                  do j=1,10
+                     do l=1,10
+                        lji = l + 10*(j-1) + 100*(i-1)
+                        lki = l + 10*(k-1) + 100*(i-1)
+                        jk = j + 10*(k-1)
+                        ! outer/inner
+                        work2(lji) = work2(lji) + work(lki)*s_s2(jk,1)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP VECTOR
+            do k=1,1000
+               r_s(k) = 0.0
+               work(k) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,10
+                  do l=1,10
+                     do i=1,10
+                        ilj = i + 10*(l-1) + 100*(j-1)
+                        ilk = i + 10*(l-1) + 100*(k-1)
+                        jk  = j + 10*(k-1)
+                        ! outer/innner
+                        r_s(ilj) = 
+     &  r_s(ilj) + d(ilj,ie)*work2(ilk)*s_s3(jk,1)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do l=1,10
+                  do j=1,10
+                     do i=1,10
+                        ijl = i + 10*(j-1) + 100*(l-1)
+                        ik = i + 10*(k-1)
+                        kjl = k + 10*(j-1) + 100*(l-1)
+                        ! inner/outer
+                        work(ijl) = work(ijl) + s_s1(ik,1) * r_s(kjl)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP VECTOR
+            do k=1,1000
+               work2(k) = 0.0
+               e(k,ie) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,10
+                  do j=1,10
+                     do l=1,10
+                        lji = l + 10*(j-1) + 100*(i-1)
+                        lki = l + 10*(k-1) + 100*(i-1)
+                        jk = j + 10*(k-1)
+                        ! outer/inner
+                        work2(lji) = 
+     &  work2(lji) + work(lki)*s_s2(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,10
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,10
+                  do l=1,10
+                     do i=1,10
+                        ilj = i + 10*(l-1) + 100*(j-1)
+                        ilk = i + 10*(l-1) + 100*(k-1)
+                        jk = j + 10*(k-1)
+                        ! outer/inner
+                        e(ilj,ie) = 
+     &  e(ilj,ie) + work2(ilk)*s_s3(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
+         enddo
+!$ACC END PARALLEL
+!$ACC END DATA
+
+      return
+      end
+c----------------------------------------------------------------------
 c----------------------------------------------------------------------
 c     clobbers r
       subroutine hsmg_do_fast(e,r,s,d,nl)

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -1083,10 +1083,15 @@ c     clobbers r
       real r(nl**ndim,nelt)
       real s(nl*nl,2,ndim,nelt)
       real d(nl**ndim,nelt)
-      integer ie,nn,i,j,k,l,i0,j0,k0,je,nu,nv
+      integer ie,nn,i,j,k,l,i0,j0,k0,je,nu,nv,lwk
       parameter (lwk=(lx1+2)*(ly1+2)*(lz1+2))
-      common /hsmgw/ work(0:lwk-1),work2(0:lwk-1)
-      real work,work2,tmp
+      real tmp
+
+      real work(1024), work2(1024)
+      real r_s(1024)
+      real s_s1(128,2)
+      real s_s2(128,2)
+      real s_s3(128,2)
 
       nn=nl**ndim
       nu=nl
@@ -1096,142 +1101,146 @@ c     clobbers r
          if(nid.eq.0) write(6,*)
      $        '2D Not currently implemented on for OpenACC'
          call exitt()
-!         do ie=1,nelt
-!            call hsmg_tnsr2d_el(e(1,ie),nl,r(1,ie),nl
-!     $                         ,s(1,2,1,ie),s(1,1,2,ie))
-!            do i=1,nn
-!               r(i,je)=d(i,ie)*e(i,ie)
-!            enddo
-!            call hsmg_tnsr2d_el(e(1,ie),nl,r(1,ie),nl
-!     $                         ,s(1,1,1,ie),s(1,2,2,ie))
-!         enddo
       else
-!$ACC PARALLEL LOOP GANG
-!$ACC&          PRESENT(e,r,s,d) PRIVATE(work,work2)
+!$ACC PARALLEL NUM_GANGS(nelt) VECTOR_LENGTH(1024)
+!$ACC LOOP GANG PRIVATE(work,work2,r_s,s_s1,s_s2,s_s3)
          do ie=1,nelt
-!            call mxm(A,nv,u,nu,work,nu*nu)
-!$ACC LOOP COLLAPSE(2) VECTOR
-            do j=1,nu*nu
-               do i=1,nv
-                  i0 = i + nv*(j-1)
-                  tmp = 0.0
-!$ACC LOOP SEQ
-                  do k=1,nu
-!                    work(i,j) = work(i,j) + A(i,k) * u(k,j)
-                     j0 = i + nv*(k-1)
-                     k0 = k + nu*(j-1)
-                     tmp = tmp + s(j0,2,1,ie) * r(k0,ie)
-                  enddo
-!$ACC END LOOP
-                  work(i0) = tmp
-               enddo
-            enddo
-!$ACC END LOOP
-
+!$ACC CACHE(r_s,work,work2,s_s1,s_s2,s_s3)
 !$ACC LOOP COLLAPSE(3) VECTOR
-            do i=1,nu
-!              call mxm(work(nv*nu*i),nv,Bt,nu,work2(nv*nv*i),nv)
-               do j=1,nv
-                  do l=1,nv
-                     i0 = l + nv*(j-1) + nv*nv*(i-1)
-                     tmp = 0.0
-!$ACC LOOP SEQ
-                     do k=1,nu
-                        j0 = l + nv*(k-1) + nv*nu*(i-1)
-                        k0 = k + nu*(j-1)
-!                       work2(j,l,i) = work2(j,l,i) + work(l,k,i)*Bt(k,j)
-                        tmp = tmp + work(j0)*s(k0,1,2,ie)
-                     enddo
-!$ACC END LOOP
-                     work2(i0) = tmp
+            do k=1,nl
+               do j=1,nl
+                  do l=1,nl
+                     ljk = l + nl*(j-1) + nl*nl*(k-1)
+                     klj = k + nl*(l-1) + nl*nl*(j-1)
+                     r_s(ljk) = r(klj,ie)
                   enddo
                enddo
             enddo
-!$ACC END LOOP
-!$ACC LOOP COLLAPSE(2) VECTOR
-!            call mxm(work2,nv*nv,Ct,nu,v,nv)
-            do j=1,nv
-               do i=1,nv*nv
-                  j0 = i + nv*nv*(j-1)
-                  tmp = 0.0
-!$ACC LOOP SEQ
-                  do k=1,nu
-                     i0 = i + nv*nv*(k-1)
-                     k0 = k + nu*(j-1)
-!                   v(i,j) = v(i,j) + work2(i,k)*Ct(k,j)
-                     tmp = tmp + work2(i0)*s(k0,1,3,ie)
-                  enddo
-!$ACC END LOOP
-                  e(j0,ie) = tmp
-               enddo
-            enddo
-!$ACC END LOOP
 !$ACC LOOP VECTOR
-            do i=1,nn
-               r(i,ie)=d(i,ie)*e(i,ie)
+            do k=1,nl*nl*nl
+               work(k) = 0.0
+               work2(k) = 0.0
             enddo
-!$ACC END LOOP
-!            call hsmg_tnsr3d_el(e(1,ie),nl,r(1,ie),nl
-!     $                         ,s(1,1,1,ie),s(1,2,2,ie),s(1,2,3,ie))
-!            call mxm(A,nv,u,nu,work,nu*nu)
-!$ACC LOOP COLLAPSE(2) VECTOR
-            do j=1,nu*nu
-               do i=1,nv
-                  i0 = i + nv*(j-1)
-                  tmp = 0
-!$ACC LOOP SEQ
-                  do k=1,nu
-!                    work(i,j) = work(i,j) + A(i,k) * u(k,j)
-                     j0 = i + nv*(k-1)
-                     k0 = k + nu*(j-1)
-                     tmp = tmp + s(j0,1,1,ie) * r(k0,ie)
-                  enddo
-!$ACC END LOOP
-                  work(i0) = tmp
-               enddo
-            enddo
-!$ACC END LOOP
-
 !$ACC LOOP COLLAPSE(3) VECTOR
-            do i=1,nu
-!              call mxm(work(nv*nu*i),nv,Bt,nu,work2(nv*nv*i),nv)
-               do j=1,nv
-                  do l=1,nv
-                     i0 = l + nv*(j-1) + nv*nv*(i-1)
-                     tmp = 0.0
+            do l=1,2
+               do j=1,nl
+                  do i=1,nl
+                     ij = i + nl*(j-1)
+                     ji = j + nl*(i-1)
+                     s_s1(ij,l) = s(ij,l,1,ie)
+                     s_s2(ji,l) = s(ij,l,2,ie)
+                     s_s3(ji,l) = s(ij,l,3,ie)
+                  enddo
+               enddo
+            enddo
 !$ACC LOOP SEQ
-                     do k=1,nu
-                        j0 = l + nv*(k-1) + nv*nu*(i-1)
-                        k0 = k + nu*(j-1)
-!                       work2(j,l,i) = work2(j,l,i) + work(l,k,i)*Bt(k,j)
-                        tmp = tmp + work(j0)*s(k0,2,2,ie)
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,nl
+                  do l=1,nl
+                     do i=1,nl
+                        ilj = i + nl*(l-1) + nl*nl*(j-1)
+                        ik = i + nl*(k-1)
+                        ljk = l + nl*(j-1) + nl*nl*(k-1)
+                        ! inner/outer
+                        work(ilj) = work(ilj) + s_s1(ik,2) * r_s(ljk)
                      enddo
-!$ACC END LOOP
-                     work2(i0) = tmp
                   enddo
                enddo
             enddo
-!$ACC END LOOP
-!$ACC LOOP COLLAPSE(2) VECTOR
-!            call mxm(work2,nv*nv,Ct,nu,v,nv)
-            do j=1,nv
-               do i=1,nv*nv
-                  j0 = i + nv*nv*(j-1)
-                  tmp = 0.0
 !$ACC LOOP SEQ
-                  do k=1,nu
-                     i0 = i + nv*nv*(k-1)
-                     k0 = k + nu*(j-1)
-!                   v(i,j) = v(i,j) + work2(i,k)*Ct(k,j)
-                     tmp = tmp + work2(i0)*s(k0,2,3,ie)
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,nl
+                  do j=1,nl
+                     do l=1,nl
+                        lji = l + nl*(j-1) + nl*nl*(i-1)
+                        lki = l + nl*(k-1) + nl*nl*(i-1)
+                        jk = j + nl*(k-1)
+                        ! outer/inner
+                        work2(lji) = work2(lji) + work(lki)*s_s2(jk,1)
+                     enddo
                   enddo
-!$ACC END LOOP
-                  e(j0,ie) = tmp
                enddo
             enddo
-!$ACC END LOOP
+
+!$ACC LOOP VECTOR
+            do k=1,nl*nl*nl
+               r_s(k) = 0.0
+               work(k) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,nl
+                  do l=1,nl
+                     do i=1,nl
+                        ilj = i + nl*(l-1) + nl*nl*(j-1)
+                        ilk = i + nl*(l-1) + nl*nl*(k-1)
+                        jk  = j + nl*(k-1)
+                        ! outer/innner
+                        r_s(ilj) = 
+     &  r_s(ilj) + d(ilj,ie)*work2(ilk)*s_s3(jk,1)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP SEQ
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do l=1,nl
+                  do j=1,nl
+                     do i=1,nl
+                        ijl = i + nl*(j-1) + nl*nl*(l-1)
+                        ik = i + nl*(k-1)
+                        kjl = k + nl*(j-1) + nl*nl*(l-1)
+                        ! inner/outer
+                        work(ijl) = work(ijl) + s_s1(ik,1) * r_s(kjl)
+                     enddo
+                  enddo
+               enddo
+            enddo
+
+!$ACC LOOP VECTOR
+            do k=1,nl*nl*nl
+               work2(k) = 0.0
+               e(k,ie) = 0.0
+            enddo
+!$ACC LOOP SEQ
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do i=1,nl
+                  do j=1,nl
+                     do l=1,nl
+                        lji = l + nl*(j-1) + nl*nl*(i-1)
+                        lki = l + nl*(k-1) + nl*nl*(i-1)
+                        jk = j + nl*(k-1)
+                        ! outer/inner
+                        work2(lji) = 
+     &  work2(lji) + work(lki)*s_s2(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
+!$ACC LOOP SEQ
+            do k=1,nl
+!$ACC LOOP COLLAPSE(3) VECTOR
+               do j=1,nl
+                  do l=1,nl
+                     do i=1,nl
+                        ilj = i + nl*(l-1) + nl*nl*(j-1)
+                        ilk = i + nl*(l-1) + nl*nl*(k-1)
+                        jk = j + nl*(k-1)
+                        ! outer/inner
+                        e(ilj,ie) = 
+     &  e(ilj,ie) + work2(ilk)*s_s3(jk,2)
+                     enddo
+                  enddo
+               enddo
+            enddo
          enddo
-!$ACC END PARALLEL LOOP
+!$ACC END PARALLEL
       endif
       return
       end


### PR DESCRIPTION
The hsmg_do_fast ACC kernel now utilizes shared memory (via !$ acc cache declarations) to optimize bandwidth. These improvements lead 3x FLOP/s for this kernel in the singlerod test case on both pascal and volta GPUs.